### PR TITLE
Changed sensing of bool attr overwrite

### DIFF
--- a/src/tasks/typeGraphqlTask/getAttributeOverwrites.ts
+++ b/src/tasks/typeGraphqlTask/getAttributeOverwrites.ts
@@ -8,7 +8,7 @@ const getAttributeOverwrites = (config: TypeGraphqlClass, indentLevel: number): 
 
   for (const attr of config.attributes) {
     if (attr.dataType.toLowerCase() === 'boolean') {
-      lines.push(prefix + `if (attributes.${attr.name} === true || attributes.${attr.name} === false) {`)
+      lines.push(prefix + `if (attributes.${attr.name} !== undefined) {`)
     } else if (attr.dataType.toLowerCase() === 'float' || attr.dataType.toLowerCase() === 'integer') {
       lines.push(prefix + `if (`)
       lines.push(prefix + `  attributes.${attr.name} === 0 ||`)


### PR DESCRIPTION
We used this so far:

```ts
if (attributes.isLive === true || attributes.isLive === false) {
```

This was changed by ESLint's `--fix` to:

```ts
if (attributes.isLive) {
```

Not what we intended. This following should ensure that we are
setting a boolean property only when it was submitted by
the `attributes` arguments:

```ts
if (attributes.isLive !== undefined) {
```

This still changes the behavior of a property that is set to `null`.